### PR TITLE
bugfix/reader-viewing-permissions

### DIFF
--- a/src/main/java/SAP/Project/simple_vcs/controllers/DocumentWebController.java
+++ b/src/main/java/SAP/Project/simple_vcs/controllers/DocumentWebController.java
@@ -13,6 +13,7 @@ import SAP.Project.simple_vcs.security.CustomUserDetails;
 import SAP.Project.simple_vcs.services.DocumentService;
 import SAP.Project.simple_vcs.services.VersionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -43,10 +44,43 @@ public class DocumentWebController {
     }
 
     @GetMapping("/document/{id}")
-    public String viewDocument(@PathVariable Long id, Model model) throws DocumentNotFoundException {
+    public String viewDocument(@PathVariable Long id, Model model,
+            @AuthenticationPrincipal CustomUserDetails userDetails) throws DocumentNotFoundException {
         Document document = documentService.getDocumentById(id);
+
+        if (isReaderOnly(userDetails)) {
+            boolean hasApprovedActive = document.getActiveVersion() != null
+                    && document.getActiveVersion().getStatus() == VersionStatus.APPROVED;
+            if (!hasApprovedActive) {
+                throw new AccessDeniedException("Readers cannot view documents without an approved version.");
+            }
+            Long userId = userDetails.getUser().getId();
+            boolean authoredByUser = document.getActiveVersion().getAuthor() != null
+                    && userId.equals(document.getActiveVersion().getAuthor().getId());
+            boolean sharedWithUser = document.getSharedWith() != null
+                    && document.getSharedWith().stream()
+                            .anyMatch(u -> userId.equals(u.getId()));
+            if (!authoredByUser && !sharedWithUser) {
+                throw new AccessDeniedException("You don't have access to this document.");
+            }
+        }
+
         model.addAttribute("document", document);
         return "file_template";
+    }
+
+    private static boolean isReaderOnly(CustomUserDetails userDetails) {
+        if (userDetails == null) return false;
+        boolean hasReader = userDetails.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_READER"));
+        boolean hasPrivileged = userDetails.getAuthorities().stream()
+                .anyMatch(a -> {
+                    String name = a.getAuthority();
+                    return name.equals("ROLE_AUTHOR")
+                            || name.equals("ROLE_REVIEWER")
+                            || name.equals("ROLE_ADMIN");
+                });
+        return hasReader && !hasPrivileged;
     }
 
     @PostMapping("/document/{id}/version/new")

--- a/src/main/java/SAP/Project/simple_vcs/controllers/WebController.java
+++ b/src/main/java/SAP/Project/simple_vcs/controllers/WebController.java
@@ -1,12 +1,13 @@
 package SAP.Project.simple_vcs.controllers;
 
 import SAP.Project.simple_vcs.dto.UserRegistrationDto;
+import SAP.Project.simple_vcs.entity.Document;
 import SAP.Project.simple_vcs.entity.User;
+import SAP.Project.simple_vcs.entity.VersionStatus;
 import SAP.Project.simple_vcs.services.DocumentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 
 import org.springframework.ui.Model;
 
@@ -27,17 +28,37 @@ public class WebController {
             if (isAdmin || isReviewer) {
                 model.addAttribute("allDocuments", documentService.getAllDocuments());
             } else {
-                java.util.List<SAP.Project.simple_vcs.entity.Document> personal =
+                boolean isAuthor = userDetails.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_AUTHOR"));
+                boolean isReaderOnly = !isAuthor && userDetails.getAuthorities().stream()
+                        .anyMatch(a -> a.getAuthority().equals("ROLE_READER"));
+
+                java.util.List<Document> personal =
                         new java.util.ArrayList<>(documentService.getPersonalDocuments(userId));
-                java.util.List<SAP.Project.simple_vcs.entity.Document> shared =
+                java.util.List<Document> shared =
                         documentService.getDocumentsSharedWithUser(userId).stream()
                                 .filter(d -> personal.stream().noneMatch(p -> p.getId().equals(d.getId())))
                                 .collect(java.util.stream.Collectors.toList());
-                model.addAttribute("myDocuments", personal);
-                model.addAttribute("sharedDocuments", shared);
+
+                if (isReaderOnly) {
+                    model.addAttribute("myDocuments", personal.stream()
+                            .filter(WebController::hasApprovedActive)
+                            .collect(java.util.stream.Collectors.toList()));
+                    model.addAttribute("sharedDocuments", shared.stream()
+                            .filter(WebController::hasApprovedActive)
+                            .collect(java.util.stream.Collectors.toList()));
+                } else {
+                    model.addAttribute("myDocuments", personal);
+                    model.addAttribute("sharedDocuments", shared);
+                }
             }
         }
         return "index";
+    }
+
+    private static boolean hasApprovedActive(Document d) {
+        return d.getActiveVersion() != null
+                && d.getActiveVersion().getStatus() == VersionStatus.APPROVED;
     }
 
     @GetMapping("/login")
@@ -67,10 +88,6 @@ public class WebController {
     public String showComparisonPage() {
         return "comparison"; // името на новия HTML файл
     }
-
-
-
-
 
 
 

--- a/src/main/resources/templates/file_template.html
+++ b/src/main/resources/templates/file_template.html
@@ -57,7 +57,9 @@
         <div class="section-divider"></div>
 
 
-        <div class="comparison-section" style="margin-bottom: 30px; padding: 20px; border-radius: 15px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);">
+        <div class="comparison-section"
+             sec:authorize="hasAnyAuthority('ROLE_AUTHOR','ROLE_REVIEWER','ROLE_ADMIN')"
+             style="margin-bottom: 30px; padding: 20px; border-radius: 15px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);">
             <h3 style="margin-bottom: 15px;">Compare Two Versions</h3>
             <div style="display: flex; gap: 15px; align-items: flex-end; flex-wrap: wrap;">
                 <div class="input-group" style="margin-bottom: 0;">
@@ -89,7 +91,8 @@
         <div class="section-divider"></div>
 
 
-        <div class="file-versions-block">
+        <div class="file-versions-block"
+             sec:authorize="hasAnyAuthority('ROLE_AUTHOR','ROLE_REVIEWER','ROLE_ADMIN')">
             <h3>Version History</h3>
             <table class="version-table">
                 <thead>


### PR DESCRIPTION
Readers can now only see documents that have an approved active version, and only the approved content — no history, no diff tool, and no direct-URL access to docs without an approved version.