### PR TITLE
feature/swagger-api-docs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
     </dependencies>
 
 	<build>

--- a/src/main/java/SAP/Project/simple_vcs/config/SecurityConfig.java
+++ b/src/main/java/SAP/Project/simple_vcs/config/SecurityConfig.java
@@ -41,7 +41,9 @@ public class SecurityConfig {
                                 "/login",
                                 "/css/**",
                                 "/js/**",
-                                "/images/**"
+                                "/images/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
                         ).permitAll()
 
 


### PR DESCRIPTION
Add SpringDoc OpenAPI dependency and permit Swagger UI endpoints in security config to enable auto-generated API documentation.