### PR TITLE
Unify button styling with solid green theme

### DIFF
--- a/src/main/resources/static/css/style_admin.css
+++ b/src/main/resources/static/css/style_admin.css
@@ -38,7 +38,7 @@
     padding: 10px 20px;
     border-radius: 50px;
     border: none;
-    background: linear-gradient(135deg, #2e7d32 0%, #81c784 100%);
+    background: #2e7d32;
     color: white;
     font-weight: 600;
     cursor: pointer;
@@ -46,16 +46,18 @@
 }
 
 .dark-theme .cta-btn {
-    background: linear-gradient(135deg, #00ffaa 0%, #0088ff 100%);
+    background: #00cc88;
     color: #161b22;
 }
 
 .cta-btn:hover {
+    background: #1b5e20;
     box-shadow: 0 5px 15px rgba(46, 125, 50, 0.4);
     transform: translateY(-2px);
 }
 
 .dark-theme .cta-btn:hover {
+    background: #00a872;
     box-shadow: 0 5px 15px rgba(0, 255, 170, 0.4);
 }
 
@@ -107,22 +109,52 @@ select, input[type="text"] {
 .status-rejected { background: rgba(244, 67, 54, 0.2); color: #d32f2f; }
 .dark-theme .status-rejected { background: rgba(244, 67, 54, 0.3); color: #e57373; }
 
+.action-btn.primary,
 .action-btn.approve {
     padding: 8px 16px;
     border-radius: 50px;
-    background: linear-gradient(135deg, #84fab0 0%, #8fd3f4 100%);
-    color: #2c3e50;
     font-weight: 600;
     border: none;
     cursor: pointer;
-    transition: transform 0.2s;
+    transition: all 0.3s ease;
 }
 
-.dark-theme .action-btn.approve {
-    background: linear-gradient(135deg, #00ffaa 0%, #0088ff 100%);
+.action-btn.primary {
+    background: #2e7d32;
     color: white;
 }
 
-.action-btn.approve:hover {
+.dark-theme .action-btn.primary {
+    background: #00cc88;
+    color: #161b22;
+}
+
+.action-btn.primary:hover {
+    background: #1b5e20;
     transform: translateY(-2px);
+}
+
+.dark-theme .action-btn.primary:hover {
+    background: #00a872;
+}
+
+.action-btn.approve {
+    background: #1b5e20;
+    color: white;
+    box-shadow: 0 2px 8px rgba(27, 94, 32, 0.3);
+}
+
+.dark-theme .action-btn.approve {
+    background: #00ffaa;
+    color: #161b22;
+    box-shadow: 0 0 12px rgba(0, 255, 170, 0.35);
+}
+
+.action-btn.approve:hover {
+    background: #0f3e13;
+    transform: translateY(-2px);
+}
+
+.dark-theme .action-btn.approve:hover {
+    background: #00e699;
 }

--- a/src/main/resources/static/css/style_document.css
+++ b/src/main/resources/static/css/style_document.css
@@ -69,23 +69,42 @@
     border: 1px solid #00ffaa;
 }
 
-.action-btn.submit-review {
-    background: linear-gradient(135deg, #a6c0fe 0%, #f68084 100%);
+.action-btn.primary {
+    background: #2e7d32;
     color: white;
 }
 
-.dark-theme .action-btn.submit-review {
-    background: linear-gradient(135deg, #f6d365 0%, #fda085 100%);
+.dark-theme .action-btn.primary {
+    background: #00cc88;
+    color: #161b22;
+}
+
+.action-btn.primary:hover {
+    background: #1b5e20;
+}
+
+.dark-theme .action-btn.primary:hover {
+    background: #00a872;
 }
 
 .action-btn.approve {
-    background: linear-gradient(135deg, #84fab0 0%, #8fd3f4 100%);
-    color: #2c3e50;
+    background: #1b5e20;
+    color: white;
+    box-shadow: 0 2px 8px rgba(27, 94, 32, 0.3);
 }
 
 .dark-theme .action-btn.approve {
-    background: linear-gradient(135deg, #00ffaa 0%, #0088ff 100%);
-    color: white;
+    background: #00ffaa;
+    color: #161b22;
+    box-shadow: 0 0 12px rgba(0, 255, 170, 0.35);
+}
+
+.action-btn.approve:hover {
+    background: #0f3e13;
+}
+
+.dark-theme .action-btn.approve:hover {
+    background: #00e699;
 }
 
 .action-btn.delete {
@@ -268,7 +287,7 @@
     height: 42px;
     border-radius: 50px;
     border: none;
-    background: linear-gradient(135deg, #2e7d32 0%, #81c784 100%);
+    background: #2e7d32;
     color: white;
     font-weight: 600;
     font-size: 14px;
@@ -281,18 +300,19 @@
 }
 
 .compare-btn:hover {
+    background: #1b5e20;
     transform: translateY(-2px);
     box-shadow: 0 6px 15px rgba(46, 125, 50, 0.35);
 }
 
 .dark-theme .compare-btn {
-    background: #00ffaa;
+    background: #00cc88;
     color: #161b22;
     box-shadow: 0 4px 10px rgba(0, 255, 170, 0.15);
 }
 
 .dark-theme .compare-btn:hover {
-    background: #00e699;
+    background: #00a872;
     box-shadow: 0 6px 15px rgba(0, 255, 170, 0.4);
 }
 

--- a/src/main/resources/static/css/style_error.css
+++ b/src/main/resources/static/css/style_error.css
@@ -40,20 +40,25 @@
     padding: 15px 40px;
     border-radius: 50px;
     border: none;
-    background: linear-gradient(135deg, #2e7d32 0%, #81c784 100%);
+    background: #2e7d32;
     color: white;
     font-weight: 600;
     cursor: pointer;
     text-decoration: none;
     font-size: 1.1rem;
-    transition: transform 0.3s;
+    transition: all 0.3s ease;
 }
 
 .cta-btn:hover {
+    background: #1b5e20;
     transform: translateY(-3px);
 }
 
 .dark-theme .cta-btn {
-    background: linear-gradient(135deg, #00ffaa 0%, #0088ff 100%);
+    background: #00cc88;
     color: #161b22;
+}
+
+.dark-theme .cta-btn:hover {
+    background: #00a872;
 }

--- a/src/main/resources/static/css/style_index.css
+++ b/src/main/resources/static/css/style_index.css
@@ -13,10 +13,15 @@
     padding: 15px 40px;
     border-radius: 50px;
     border: none;
-    background: white;
-    color: #4a6fa5;
+    background: #2e7d32;
+    color: white;
     font-weight: 600;
     cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.light-theme .cta-btn:hover {
+    background: #1b5e20;
 }
 
 .dark-theme .about {
@@ -29,10 +34,15 @@
     padding: 15px 40px;
     border-radius: 50px;
     border: none;
-    background: #00ffaa;
+    background: #00cc88;
     color: #161b22;
     font-weight: 600;
     cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.dark-theme .cta-btn:hover {
+    background: #00a872;
 }
 
 /* Document Cards section */

--- a/src/main/resources/templates/admin_dashboard.html
+++ b/src/main/resources/templates/admin_dashboard.html
@@ -125,7 +125,7 @@
                                 <span th:if="${doc.activeVersion == null}" style="color: #999;">-</span>
                             </td>
                             <td style="padding: 12px;">
-                                <a th:href="@{/document/{id}(id=${doc.id})}" class="action-btn approve" style="text-decoration: none; display: inline-block;">View / Manage</a>
+                                <a th:href="@{/document/{id}(id=${doc.id})}" class="action-btn primary" style="text-decoration: none; display: inline-block;">View / Manage</a>
                             </td>
                         </tr>
                     </tbody>

--- a/src/main/resources/templates/file_template.html
+++ b/src/main/resources/templates/file_template.html
@@ -120,7 +120,7 @@
                                       method="post" style="display:inline;"
                                       sec:authorize="hasAnyAuthority('ROLE_AUTHOR','ROLE_REVIEWER','ROLE_ADMIN')">
                                     <input type="hidden" name="newStatus" value="PENDING_REVIEW"/>
-                                    <button type="submit" class="action-btn submit-review">Submit for Review</button>
+                                    <button type="submit" class="action-btn primary">Submit for Review</button>
                                 </form>
 
                                 <!-- Approve: reviewer or admin, only on PENDING_REVIEW -->
@@ -172,19 +172,19 @@
                     <textarea id="newCommentContent" class="comment-textarea"
                         placeholder="Add your thoughts..."></textarea>
                     <div style="display: flex; justify-content: flex-end; margin-top: 5px;">
-                        <button type="button" class="action-btn approve" onclick="submitNewComment()">Post Comment</button>
+                        <button type="button" class="action-btn primary" onclick="submitNewComment()">Post Comment</button>
                     </div>
                 </div>
             </div>
 
             <!-- New Version Button -->
             <div sec:authorize="hasAnyAuthority('ROLE_AUTHOR','ROLE_REVIEWER','ROLE_ADMIN')" style="margin-top: 20px;">
-                <button class="action-btn approve" onclick="openNewVersionModal()">+ New Version</button>
+                <button class="action-btn primary" onclick="openNewVersionModal()">+ New Version</button>
             </div>
 
             <!-- Share Section -->
             <div sec:authorize="hasAnyAuthority('ROLE_AUTHOR','ROLE_REVIEWER','ROLE_ADMIN')" style="margin-top: 12px;">
-                <button class="action-btn submit-review" onclick="openShareModal()">Share Document</button>
+                <button class="action-btn primary" onclick="openShareModal()">Share Document</button>
                 <div th:if="${document.sharedWith != null and !document.sharedWith.empty}" style="margin-top: 10px; font-size: 0.88rem; color: #555;">
                     Shared with:
                     <span th:each="u, iter : ${document.sharedWith}">
@@ -207,7 +207,7 @@
                        style="width:100%; padding:10px 12px; border-radius:8px; border:1px solid rgba(0,0,0,0.2); font-size:0.95rem; box-sizing:border-box;" required/>
                 <div style="display:flex; gap:10px; margin-top:16px; justify-content:flex-end;">
                     <button type="button" onclick="closeShareModal()" class="action-btn revert">Cancel</button>
-                    <button type="submit" class="action-btn approve">Share</button>
+                    <button type="submit" class="action-btn primary">Share</button>
                 </div>
             </form>
         </div>
@@ -225,7 +225,7 @@
                           style="width:100%; padding:12px; border-radius:8px; border:1px solid rgba(0,0,0,0.2); font-size:0.95rem; resize:vertical; box-sizing:border-box; font-family:inherit;"></textarea>
                 <div style="display:flex; gap:10px; margin-top:16px; justify-content:flex-end;">
                     <button type="button" onclick="closeNewVersionModal()" class="action-btn revert">Cancel</button>
-                    <button type="submit" class="action-btn approve">Create Version</button>
+                    <button type="submit" class="action-btn primary">Create Version</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- Remove gradients from all button selectors (`.cta-btn`, `.compare-btn`, `.action-btn.approve`, and the former `.action-btn.submit-review`) and replace with a single solid-green system.
- Introduce `.action-btn.primary` for standard actions (`#2e7d32` light / `#00cc88` dark); keep `.action-btn.approve` visually distinct as the decisive action (`#1b5e20` light / `#00ffaa` dark, subtle shadow).
- Reject stays red as a semantic exception; outlined `.action-btn.revert` is unchanged.
- Reassign non-approve buttons in `file_template.html` and `admin_dashboard.html` to the new `primary` class.