### PR TITLE
bugfix/theme-polish

### DIFF
--- a/src/main/resources/static/css/style_admin.css
+++ b/src/main/resources/static/css/style_admin.css
@@ -10,29 +10,6 @@
     width: 100%;
 }
 
-.glass-card {
-    background: rgba(255, 255, 255, 0.7) !important;
-    backdrop-filter: blur(20px);
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08) !important;
-}
-
-.dark-theme .glass-card {
-    background: rgba(22, 27, 34, 0.8) !important;
-    border: 1px solid #30363d;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4) !important;
-}
-
-:root {
-    --text-color: #333;
-    --primary-color: rgba(46, 125, 50, 0.2);
-}
-
-.dark-theme {
-    --text-color: #cfd0d2;
-    --primary-color: rgba(0, 255, 170, 0.2);
-}
-
 /* Reusing .cta-btn from style_index.css but redefining for standalone use if extracted */
 .cta-btn {
     padding: 10px 20px;
@@ -87,6 +64,23 @@ select, input[type="text"] {
     background: rgba(0, 0, 0, 0.2);
     color: #fff;
     border-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.dark-theme select option {
+    background: #1f242d;
+    color: #e6edf3;
+}
+
+.dark-theme #detailsModal {
+    border: 1px solid #30363d;
+}
+
+#detailsModal::backdrop {
+    background: rgba(0, 0, 0, 0.4);
+}
+
+.dark-theme #detailsModal::backdrop {
+    background: rgba(0, 0, 0, 0.65);
 }
 
 .status-tag {

--- a/src/main/resources/static/css/style_document.css
+++ b/src/main/resources/static/css/style_document.css
@@ -282,6 +282,75 @@
 
 /* === version comparison diff === */
 
+.comparison-section {
+    margin-bottom: 30px;
+    padding: 24px;
+    border-radius: 15px;
+}
+
+.comparison-section h3 {
+    margin: 0 0 18px 0;
+    color: var(--text-color);
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.compare-row {
+    display: flex;
+    gap: 16px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.comparison-section .input-group {
+    margin-bottom: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.comparison-section .input-group label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-color);
+    opacity: 0.8;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.version-select {
+    width: 220px;
+    padding: 9px 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    background: rgba(255, 255, 255, 0.7);
+    color: #333;
+    font-size: 0.9rem;
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.version-select:focus {
+    border-color: #2e7d32;
+    box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.15);
+}
+
+.dark-theme .version-select {
+    background: rgba(0, 0, 0, 0.25);
+    color: #e6edf3;
+    border-color: rgba(255, 255, 255, 0.15);
+}
+
+.dark-theme .version-select:focus {
+    border-color: #00ffaa;
+    box-shadow: 0 0 0 3px rgba(0, 255, 170, 0.2);
+}
+
+.dark-theme .version-select option {
+    background: #1f242d;
+    color: #e6edf3;
+}
+
 .compare-btn {
     padding: 0 24px;
     height: 42px;

--- a/src/main/resources/static/css/style_layout.css
+++ b/src/main/resources/static/css/style_layout.css
@@ -5,6 +5,31 @@
     font-family: 'Inter', sans-serif;
 }
 
+:root {
+    --text-color: #333;
+    --primary-color: rgba(46, 125, 50, 0.2);
+    --bg-color: #ffffff;
+}
+
+.dark-theme {
+    --text-color: #cfd0d2;
+    --primary-color: rgba(0, 255, 170, 0.2);
+    --bg-color: #161b22;
+}
+
+.glass-card {
+    background: rgba(255, 255, 255, 0.7) !important;
+    backdrop-filter: blur(20px);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.08) !important;
+}
+
+.dark-theme .glass-card {
+    background: rgba(22, 27, 34, 0.8) !important;
+    border: 1px solid #30363d;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4) !important;
+}
+
 /* Responsive Typography */
 h1 {
     font-size: clamp(1rem, 2.5vw, 2.75rem);
@@ -134,10 +159,10 @@ p {
 
 
   .dark-theme .nav-btn:hover {
-    background: linear-gradient(to right, #1f242d, #00ffaa);
-    color: #033e2b;
-    border: 1px solid #00ffaa; /* Subtle blue border */
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    background: linear-gradient(to right, rgba(0, 255, 170, 0.08), rgba(0, 255, 170, 0.3));
+    color: #00ffaa;
+    border: 1px solid #00ffaa;
+    box-shadow: 0 2px 8px rgba(0, 255, 170, 0.2);
   }
 
   .menu-toggle {
@@ -193,11 +218,11 @@ p {
 
 
 
-  body.dark-theme .light-state-icon {
+  .dark-theme .light-state-icon {
     display: none;
   }
 
-  body.dark-theme .dark-state-icon {
+  .dark-theme .dark-state-icon {
     display: block;
   }
 

--- a/src/main/resources/static/css/style_login_register.css
+++ b/src/main/resources/static/css/style_login_register.css
@@ -156,6 +156,56 @@
     font-size: 14px;
     border: 1px solid transparent;
     outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  }
+
+  .light-theme .input-group input {
+    background: rgba(255, 255, 255, 0.9);
+    color: #1c1c1c;
+    border-color: rgba(46, 125, 50, 0.25);
+  }
+
+  .light-theme .input-group input::placeholder {
+    color: rgba(0, 0, 0, 0.35);
+  }
+
+  .light-theme .input-group input:focus {
+    background: #ffffff;
+    border-color: #2e7d32;
+    box-shadow: 0 0 0 3px rgba(46, 125, 50, 0.15);
+  }
+
+  .dark-theme .input-group input {
+    background: rgba(0, 0, 0, 0.3);
+    color: #e6edf3;
+    border-color: rgba(255, 255, 255, 0.15);
+  }
+
+  .dark-theme .input-group input::placeholder {
+    color: rgba(230, 237, 243, 0.4);
+  }
+
+  .dark-theme .input-group input:focus {
+    background: rgba(0, 0, 0, 0.4);
+    border-color: #00ffaa;
+    box-shadow: 0 0 0 3px rgba(0, 255, 170, 0.2);
+  }
+
+  /* Browser autofill override — Chrome/Safari force a blue/yellow bg by default */
+  .light-theme .input-group input:-webkit-autofill,
+  .light-theme .input-group input:-webkit-autofill:hover,
+  .light-theme .input-group input:-webkit-autofill:focus {
+    -webkit-box-shadow: 0 0 0 30px rgba(255, 255, 255, 0.95) inset;
+    -webkit-text-fill-color: #1c1c1c;
+    caret-color: #1c1c1c;
+  }
+
+  .dark-theme .input-group input:-webkit-autofill,
+  .dark-theme .input-group input:-webkit-autofill:hover,
+  .dark-theme .input-group input:-webkit-autofill:focus {
+    -webkit-box-shadow: 0 0 0 30px #1f242d inset;
+    -webkit-text-fill-color: #e6edf3;
+    caret-color: #e6edf3;
   }
 
   .login-submit {
@@ -168,6 +218,31 @@
     cursor: pointer;
     margin-top: 10px;
     border: none;
+    transition: all 0.3s ease;
+  }
+
+  .light-theme .login-submit {
+    background: #2e7d32;
+    color: #ffffff;
+    box-shadow: 0 4px 12px rgba(46, 125, 50, 0.25);
+  }
+
+  .light-theme .login-submit:hover {
+    background: #1b5e20;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(46, 125, 50, 0.4);
+  }
+
+  .dark-theme .login-submit {
+    background: #00cc88;
+    color: #0d1117;
+    box-shadow: 0 4px 12px rgba(0, 255, 170, 0.2);
+  }
+
+  .dark-theme .login-submit:hover {
+    background: #00a872;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0, 255, 170, 0.4);
   }
 
 
@@ -222,12 +297,4 @@
 @keyframes fadeIn {
   from { opacity: 0; transform: translateX(-15px); }
   to { opacity: 1; transform: translateX(0); }
-}
-.login-submit {
-  width: 100%;
-  padding: 14px;
-  border-radius: 15px;
-  font-weight: 700;
-  cursor: pointer;
-  border: none;
 }

--- a/src/main/resources/static/js/javascript_index.js
+++ b/src/main/resources/static/js/javascript_index.js
@@ -4,27 +4,16 @@ function toggleTheme(event) {
 }
 
 const themeBtn = document.getElementById('theme-switcher');
-const body = document.body;
+const root = document.documentElement;
 
 if (themeBtn) {
     themeBtn.addEventListener('click', () => {
-        body.classList.toggle('dark-theme');
-        if (body.classList.contains('dark-theme')) {
-            localStorage.setItem('theme', 'dark');
-        } else {
-            localStorage.setItem('theme', 'light');
-        }
+        const nowDark = !root.classList.contains('dark-theme');
+        root.classList.toggle('dark-theme', nowDark);
+        root.classList.toggle('light-theme', !nowDark);
+        localStorage.setItem('theme', nowDark ? 'dark' : 'light');
     });
 }
-
-(function () {
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') {
-        document.body.classList.add('dark-theme');
-    } else {
-        document.body.classList.remove('dark-theme');
-    }
-})();
 
 function toggleForms() {
     const login = document.getElementById('login-side');

--- a/src/main/resources/templates/admin_dashboard.html
+++ b/src/main/resources/templates/admin_dashboard.html
@@ -3,7 +3,7 @@
 
 <head th:replace="~{fragments/layout :: common_head('ITEAC - Admin Dashboard', 'style_admin.css')}"></head>
 
-<body class="light-theme dashboard-body">
+<body class="dashboard-body">
 
     <header th:replace="~{fragments/layout :: navbar}"></header>
 
@@ -26,6 +26,12 @@
         .role-pill input[type="checkbox"]:focus-visible + span {
             outline: 2px solid var(--primary-color);
             outline-offset: 1px;
+        }
+        .dark-theme .role-pill:hover span { background-color: rgba(255, 255, 255, 0.08); }
+        .dark-theme .role-pill input[type="checkbox"]:checked + span {
+            background-color: rgba(0, 255, 170, 0.2);
+            color: #00ffaa;
+            font-weight: 600;
         }
     </style>
 

--- a/src/main/resources/templates/audit_logs.html
+++ b/src/main/resources/templates/audit_logs.html
@@ -3,7 +3,7 @@
 
 <head th:replace="~{fragments/layout :: common_head('ITEAC - Audit Logs', 'style_admin.css')}"></head>
 
-<body class="light-theme dashboard-body">
+<body class="dashboard-body">
 
     <header th:replace="~{fragments/layout :: navbar}"></header>
 

--- a/src/main/resources/templates/document_creation.html
+++ b/src/main/resources/templates/document_creation.html
@@ -2,7 +2,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <head th:replace="~{fragments/layout :: common_head('ITEAC - Document', 'style_login_register.css')}"></head>
-<body class="light-theme">
+<body>
 
 
 <header th:replace="~{fragments/layout :: navbar}"></header>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head th:replace="~{fragments/layout :: common_head('ITEAC - Document', 'style_error.css')}"></head>
-<body class="light-theme">
+<body>
 
 <header class="navbar">
     <div class="logo">

--- a/src/main/resources/templates/file_template.html
+++ b/src/main/resources/templates/file_template.html
@@ -3,7 +3,7 @@
 
 <head th:replace="~{fragments/layout :: common_head('ITEAC - Home', 'style_document.css')}"></head>
 
-<body class="light-theme">
+<body>
 
     <header th:replace="~{fragments/layout :: navbar}"></header>
 
@@ -55,21 +55,20 @@
 
             <div class="section-divider"></div>
 
-            <div class="comparison-section" sec:authorize="hasAnyAuthority('ROLE_AUTHOR','ROLE_REVIEWER','ROLE_ADMIN')"
-                style="margin-bottom: 30px; padding: 20px; border-radius: 15px; background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.1);">
-                <h3 style="margin-bottom: 15px;">Compare Two Versions</h3>
-                <div style="display: flex; gap: 15px; align-items: flex-end; flex-wrap: wrap;">
-                    <div class="input-group" style="margin-bottom: 0;">
-                        <label>Base Version (Old):</label>
-                        <select id="oldVersionId" class="nav-btn" style="width: 220px; background: white; color: #333;">
+            <div class="comparison-section glass-card" sec:authorize="hasAnyAuthority('ROLE_AUTHOR','ROLE_REVIEWER','ROLE_ADMIN')">
+                <h3>Compare versions</h3>
+                <div class="compare-row">
+                    <div class="input-group">
+                        <label for="oldVersionId">From</label>
+                        <select id="oldVersionId" class="version-select">
                             <option value="" disabled selected>Select version</option>
                             <option th:each="v : ${document.versions}" th:value="${v.id}"
                                 th:text="'v' + ${v.versionNumber} + ' (' + ${v.status} + ')'"></option>
                         </select>
                     </div>
-                    <div class="input-group" style="margin-bottom: 0;">
-                        <label>Compare With (New):</label>
-                        <select id="newVersionId" class="nav-btn" style="width: 220px; background: white; color: #333;">
+                    <div class="input-group">
+                        <label for="newVersionId">To</label>
+                        <select id="newVersionId" class="version-select">
                             <option value="" disabled selected>Select version</option>
                             <option th:each="v : ${document.versions}" th:value="${v.id}"
                                 th:text="'v' + ${v.versionNumber} + ' (' + ${v.status} + ')'"></option>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -4,6 +4,16 @@
 <head th:fragment="common_head(title, cssFile)">
     <meta charset="UTF-8">
     <title th:text="${title}">ITEAC</title>
+    <script th:inline="none">
+        (function () {
+            try {
+                var saved = localStorage.getItem('theme');
+                document.documentElement.classList.add(saved === 'dark' ? 'dark-theme' : 'light-theme');
+            } catch (e) {
+                document.documentElement.classList.add('light-theme');
+            }
+        })();
+    </script>
     <link rel="stylesheet" th:href="@{/css/style_layout.css}">
     <link th:if="${cssFile != null}" rel="stylesheet" th:href="@{/css/} + ${cssFile}">
 </head>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -2,7 +2,7 @@
 <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <head th:replace="~{fragments/layout :: common_head('ITEAC - Home', 'style_index.css')}"></head>
-<body class="light-theme">
+<body>
 
 <header th:replace="~{fragments/layout :: navbar}"></header>
 

--- a/src/main/resources/templates/login_register.html
+++ b/src/main/resources/templates/login_register.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head th:replace="~{fragments/layout :: common_head('ITEAC - Login&Register', 'style_login_register.css')}"></head>
-<body class="light-theme">
+<body>
 
 
 <header th:replace="~{fragments/layout :: navbar}"></header>


### PR DESCRIPTION
- Fix dark-theme flash on navigation by setting the theme class on `<html>` via a synchronous inline script in `common_head` (runs before first paint).
- Polish theme-specific UI: navbar hover, audit logs (filter dropdown + details modal), version compare (glass-card + themed selects, relabeled From/To), login/register (themed inputs with autofill override + themed submit button), admin role pills.
- Promote `.glass-card` and theme `:root` vars from `style_admin.css` into `style_layout.css` so they're globally available.